### PR TITLE
Make crawl tracker async

### DIFF
--- a/simple_crawler/downloader.py
+++ b/simple_crawler/downloader.py
@@ -63,7 +63,7 @@ class SiteDownloader:
         if not self.can_fetch(url):
             msg = f"Skipping {url} (not allowed by robots.txt)"
             logger.info(msg)
-            self.on_failure(url, "disallowed", "", 403)
+            self.on_failure(url, "disallowed", 403)
             return None, 403
 
         # Get the page elementsupdate_urlupdate_url
@@ -77,6 +77,6 @@ class SiteDownloader:
             # and closed the url out, not passing it to the parser
             logger.error(f"Error getting {url}: {e}")
             if cache_results:
-                self.on_failure(url, "error", response.text, response.status_code)
+                self.on_failure(url, "error", response.status_code)
             raise e
         return response.text, response.status_code

--- a/simple_crawler/downloader.py
+++ b/simple_crawler/downloader.py
@@ -13,8 +13,6 @@ logger = get_logger("downloader")
 class SiteDownloader:
     def __init__(self, manager: Manager, write_to_db: bool = True):
         self.manager = manager
-        self.cache = manager.cache
-        self.db_manager = manager.db_manager
         self.crawl_tracker = manager.crawl_tracker
         self.write_to_db = write_to_db
 
@@ -46,11 +44,16 @@ class SiteDownloader:
         return sitemap_url, rrate, crawl_delay
 
     def on_success(self, url: str, content: str, status_code: int):
-        update_map = {'content': content, 'attrs': {"crawl_status": "downloaded", "status_code": status_code}}
+        update_map = {
+            "content": content,
+            "attrs": {"crawl_status": "downloaded", "status_code": status_code},
+        }
         _ = self.crawl_tracker.update_url(url, update_map)
 
     def on_failure(self, url: str, crawl_status: str, status_code: int):
-        update_map = {'attrs': {"crawl_status": crawl_status, "status_code": status_code}}
+        update_map = {
+            "attrs": {"crawl_status": crawl_status, "status_code": status_code}
+        }
         _ = self.crawl_tracker.update_url(url, update_map, close=True)
 
     def get_page_elements(self, url: str, cache_results: bool = True) -> set[str]:

--- a/simple_crawler/downloader.py
+++ b/simple_crawler/downloader.py
@@ -46,12 +46,12 @@ class SiteDownloader:
         return sitemap_url, rrate, crawl_delay
 
     def on_success(self, url: str, content: str, status_code: int):
-        self.cache.update_content(url, content, status_code)
-        _ = self.crawl_tracker.update_status(url, "downloaded", status_code)
+        update_map = {'content': content, 'attrs': {"crawl_status": "downloaded", "status_code": status_code}}
+        _ = self.crawl_tracker.update_url(url, update_map)
 
-    def on_failure(self, url: str, crawl_status: str, content: str, status_code: int):
-        self.cache.update_content(url, content, status_code)
-        _ = self.crawl_tracker.update_status(url, crawl_status, status_code)
+    def on_failure(self, url: str, crawl_status: str, status_code: int):
+        update_map = {'attrs': {"crawl_status": crawl_status, "status_code": status_code}}
+        _ = self.crawl_tracker.update_url(url, update_map, close=True)
 
     def get_page_elements(self, url: str, cache_results: bool = True) -> set[str]:
         """Get the page elements from a webpage"""
@@ -63,7 +63,7 @@ class SiteDownloader:
             self.on_failure(url, "disallowed", "", 403)
             return None, 403
 
-        # Get the page elementsupdate_statusupdate_status
+        # Get the page elementsupdate_urlupdate_url
         try:
             response = requests.get(url, timeout=1)
             response.raise_for_status()

--- a/simple_crawler/main.py
+++ b/simple_crawler/main.py
@@ -84,9 +84,7 @@ async def download_url_while_true(
                             await asyncio.sleep(10)
                     manager.crawl_tracker.request_parse(url)
                     if content is not None:
-                        await asyncio.wait_for(
-                            parse_queue.put((url, content)), timeout=1
-                        )
+                        await asyncio.wait_for(parse_queue.put((url,)), timeout=1)
                     logger.debug("try loop exit")
                 else:
                     empty_count += 1
@@ -116,9 +114,9 @@ async def parse_while_true(
     while True and empty_count <= max_empty_count:
         if not parse_queue.empty():
             empty_count = 0
-            url, content = await asyncio.wait_for(parse_queue.get(), timeout=1)
-            logger.info(f"Content received for {url}, parsing...")
-            link_list = parser.parse(url, content)
+            url = await asyncio.wait_for(parse_queue.get(), timeout=1)
+            logger.info(f"Request received for {url}, parsing...")
+            link_list = parser.parse(url)
             for link in link_list:
                 links.append(link)
             if len(links) == 0:

--- a/simple_crawler/main.py
+++ b/simple_crawler/main.py
@@ -30,7 +30,7 @@ async def prime_queue(seed_url: str):
         sitemap_url, sitemap_indexes, sitemap_details = mapper.get_sitemap()
     except Exception as e:
         logger.error(f"Error getting sitemap for {seed_url}: {e}")
-        manager.crawl_tracker.add_page_to_visit(seed_url)
+        manager.crawl_tracker.request_download(seed_url)
 
 
 async def process_url_while_true(
@@ -82,7 +82,7 @@ async def download_url_while_true(
                             )
                             check_every = check_every * 1.5
                             await asyncio.sleep(10)
-                    manager.crawl_tracker.add_page_visited(url)
+                    manager.crawl_tracker.request_parse(url)
                     if content is not None:
                         await asyncio.wait_for(
                             parse_queue.put((url, content)), timeout=1

--- a/simple_crawler/manager.py
+++ b/simple_crawler/manager.py
@@ -13,7 +13,7 @@ from data import DatabaseManager
 loc = os.path.dirname(__file__)
 sys.path.append(loc)
 
-from cache import CrawlTracker, URLCache  # noqa
+from cache import CrawlTracker  # noqa
 from config.configuration import REDIS_HOST  # noqa
 from config.configuration import (DATA_DIR, RDB_FILE, REDIS_PORT,
                                   SQLITE_DB_FILE, get_logger)
@@ -96,7 +96,6 @@ class Manager:
         self.db_manager = DatabaseManager(self.url_pubsub, self.sqlite_path)
 
     def _init_cache(self):
-        self.cache = URLCache(self.rdb)
         self.crawl_tracker = CrawlTracker(
             self.host, self.port, self.seed_url, self.run_id, self.max_pages
         )

--- a/simple_crawler/parser.py
+++ b/simple_crawler/parser.py
@@ -40,17 +40,18 @@ class Parser:
             # Only include URLs from the same domain
             if urlparse(absolute_url).netloc == urlparse(url).netloc:
                 links.add(absolute_url)
-                self.crawl_tracker.add_page_to_visit(absolute_url)
+                self.crawl_tracker.request_download(absolute_url)
         return links
 
     def on_success(self, url, links):
         """Callback for when a job succeeds"""
-        self.crawl_tracker.store_linked_urls(url, links)
-        _ = self.crawl_tracker.update_status(url, "parsed")
+        update_map = {'attrs': {"crawl_status": "parsed"}, 'linked_urls': links}
+        _ = self.crawl_tracker.update_url(url, update_map, close=True)
 
     def on_failure(self, url):
         """Callback for when a job fails"""
-        _ = self.crawl_tracker.update_status(url, "error")
+        update_map = {'attrs': {"crawl_status": "error"}}
+        _ = self.crawl_tracker.update_url(url, update_map, close=True)
 
     # Crawling Logic
     def parse(self, url, content):

--- a/simple_crawler/parser.py
+++ b/simple_crawler/parser.py
@@ -43,7 +43,7 @@ class Parser:
     def on_success(self, url, links):
         """Callback for when a job succeeds"""
         update_map = {"attrs": {"crawl_status": "parsed"}, "linked_urls": links}
-        _ = self.crawl_tracker.update_url(url, update_map, close=True)
+        _ = self.crawl_tracker.update_url(url, update_map)
 
     def on_failure(self, url):
         """Callback for when a job fails"""
@@ -59,7 +59,6 @@ class Parser:
         logger.debug(f"Parsing {url}")
         try:
             links = self.get_links_from_content(url, content)
-            logger.info(f"Found {len(links)} links in {url}")
             self.on_success(url, list(links))
         except Exception as e:
             logger.error(f"Error parsing {url}: {e}")

--- a/simple_crawler/parser.py
+++ b/simple_crawler/parser.py
@@ -16,9 +16,6 @@ logger = get_logger("parser")
 class Parser:
     def __init__(self, manager: Manager, write_to_db: bool = True, url: str = None):
         self.url = url
-        self.manager = manager
-        self.cache = manager.cache
-        self.db_manager = manager.db_manager
         self.crawl_tracker = manager.crawl_tracker
         self.write_to_db = write_to_db
 
@@ -45,17 +42,19 @@ class Parser:
 
     def on_success(self, url, links):
         """Callback for when a job succeeds"""
-        update_map = {'attrs': {"crawl_status": "parsed"}, 'linked_urls': links}
+        update_map = {"attrs": {"crawl_status": "parsed"}, "linked_urls": links}
         _ = self.crawl_tracker.update_url(url, update_map, close=True)
 
     def on_failure(self, url):
         """Callback for when a job fails"""
-        update_map = {'attrs': {"crawl_status": "error"}}
+        update_map = {"attrs": {"crawl_status": "error"}}
         _ = self.crawl_tracker.update_url(url, update_map, close=True)
 
     # Crawling Logic
-    def parse(self, url, content):
+    def parse(self, url, content=None):
         """Main crawling method"""
+        if content is None:
+            content = self.crawl_tracker.get_cached_response(url)
         links = set()
         logger.debug(f"Parsing {url}")
         try:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,23 +1,21 @@
 from __future__ import annotations
 
 import pytest
+import json
+from unittest.mock import AsyncMock
 
-from simple_crawler.cache import CrawlStatus, CrawlTracker, URLCache, URLData
-
-
-@pytest.fixture
-def url_cache(redis_conn):
-    return URLCache(redis_conn)
+from simple_crawler.utils import deserialize
+from simple_crawler.cache import CrawlStatus, CrawlTracker
 
 
 @pytest.fixture
-def crawl_tracker(redis_conn):
-    return CrawlTracker(redis_conn)
+def crawl_tracker(async_redis_conn):
+    return CrawlTracker(async_redis_conn, "http://example.com", "test_run", 100)
 
 
 @pytest.fixture
 def sample_url():
-    return "https://example.com"
+    return "http://example.com/public/"
 
 
 @pytest.fixture
@@ -26,88 +24,186 @@ def sample_html_content():
 
 
 @pytest.fixture
-def sample_url_data(sample_url, sample_html_content):
-    return URLData(
-        url=sample_url,
-        content=sample_html_content,
-        req_status=200,
-        crawl_status=CrawlStatus.FRONTIER.value,
-        run_id="test_run",
-    )
+def sample_url_attrs():
+    return {
+        "seed_url": "http://example.com",
+        "req_status": 200,
+        "crawl_status": 0,
+        "run_id": "run_0",
+        "max_pages": 100,
+    }
+
+
+@pytest.fixture
+def sample_linked_urls():
+    return [
+        "https://github.com/hadialqattan/pycln",
+        "https://github.com/asottile/pyupgrade",
+        "https://github.com/codespell-project/codespell",
+    ]
 
 
 @pytest.fixture
 def sample_failed_url_data(sample_url):
-    return URLData(
-        url=sample_url,
-        content=sample_html_content,
-        req_status=404,
-        crawl_status=CrawlStatus.ERROR.value,
-        run_id="test_run",
+    return {
+        "url": sample_url,
+        "req_status": 404,
+        "crawl_status": CrawlStatus.ERROR.value,
+        "run_id": "test_run",
+    }
+
+
+@pytest.mark.asyncio
+async def test_init_url_data(crawl_tracker, sample_url):
+    """Test initializing URL data in the tracker"""
+    await crawl_tracker.init_url_data(sample_url)
+
+    # Check that URL data was initialized correctly
+    key = f"urls:{sample_url}"
+    test = await crawl_tracker.rdb.hgetall(f"{key}:attrs")
+    test = await deserialize(test)
+    assert test["seed_url"] == crawl_tracker.seed_url
+    assert test["run_id"] == crawl_tracker.run_id
+    assert int(test["crawl_status"]) == 0
+    assert int(test["max_pages"]) == crawl_tracker.max_pages
+
+
+@pytest.mark.asyncio
+async def test_request_download(crawl_tracker, sample_url):
+    """Test requesting a URL for download"""
+
+    # First request should return True (new URL)
+    is_new = await crawl_tracker.request_download(sample_url)
+    assert is_new is True
+
+    is_new = await crawl_tracker.request_download(sample_url)
+    assert is_new is False
+
+    # Verify sadd was called with correct arguments
+    # crawl_tracker.rdb.sadd.assert_called_with("download_requests", sample_url)
+    test = await crawl_tracker.rdb.smembers("download_requests")
+    assert sample_url == test.pop().decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_get_page_to_visit(crawl_tracker, sample_url):
+    """Test getting next page to visit from queue"""
+    # Mock lpop to return URL
+
+    # Get next URL
+    next_url = await crawl_tracker.get_page_to_visit()
+    assert next_url == sample_url
+
+    other_url = "https://github.com/hadialqattan/pycln"
+    is_new = await crawl_tracker.request_download(other_url)
+    assert is_new
+
+    # Queue should be empty
+    next_url = await crawl_tracker.get_page_to_visit()
+    assert next_url == other_url
+
+    next_url = await crawl_tracker.get_page_to_visit()
+    assert next_url is None
+
+
+@pytest.mark.asyncio
+async def test_request_parse(crawl_tracker, sample_url):
+    """Test requesting a URL for parsing"""
+
+    # First request should return True (new URL)
+    is_new = await crawl_tracker.request_parse(sample_url)
+    assert is_new is True
+
+    is_new = await crawl_tracker.request_parse(sample_url)
+    assert is_new is False
+
+    test = await crawl_tracker.rdb.smembers("parse_requests")
+    assert sample_url == test.pop().decode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_update_url(crawl_tracker, sample_url):
+    """Test updating URL data"""
+    url_data = {
+        "attrs": {"crawl_status": CrawlStatus.DOWNLOADED.value, "req_status": 200},
+        "linked_urls": ["http://example.com/1", "http://example.com/2"],
+        "content": "<html>Test</html>",
+    }
+
+    await crawl_tracker.update_url(sample_url, url_data)
+
+    key = f"urls:{sample_url}"
+    b_data = await crawl_tracker.rdb.hgetall(f"{key}:attrs")
+    data = await deserialize(b_data)
+    assert data["seed_url"] == crawl_tracker.seed_url
+    assert data["run_id"] == crawl_tracker.run_id
+    assert int(data["crawl_status"]) == 1
+    assert int(data["max_pages"]) == crawl_tracker.max_pages
+
+    linked_urls = await crawl_tracker.rdb.lrange(f"{key}:linked_urls", 0, -1)
+    urls = [url.decode("utf-8") for url in linked_urls]
+    assert all([x in urls for x in url_data["linked_urls"]])
+
+    content = await crawl_tracker.rdb.get(f"{key}:content")
+    assert content.decode("utf-8") == url_data["content"]
+    await crawl_tracker.rdb.delete(key)
+
+
+@pytest.mark.asyncio
+async def test_close_url(crawl_tracker, sample_url):
+    """Test closing a URL and publishing its data"""
+
+    crawl_tracker.rdb.publish = AsyncMock()
+    crawl_tracker.rdb.publish.return_value = True
+
+    await crawl_tracker.close_url(sample_url)
+
+    completed_pages = await crawl_tracker.rdb.get("completed_pages")
+    assert int(completed_pages) == 1
+
+    await crawl_tracker.close_url(sample_url)
+
+    completed_pages = await crawl_tracker.rdb.get("completed_pages")
+    assert int(completed_pages) == 2
+
+    # Verify publish was called with correct data
+    key = f"urls:{sample_url}"
+    assert crawl_tracker.rdb.publish.call_args[0] == (
+        "db",
+        json.dumps({"key": key, "table_name": "urls"}),
     )
 
 
-class TestURLData:
-    def test_url_data_creation(self, sample_url_data):
-        assert sample_url_data.url == "https://example.com"
-        assert sample_url_data.req_status == 200
-        assert sample_url_data.crawl_status == CrawlStatus.FRONTIER.value
-        assert isinstance(sample_url_data.content, str)
+@pytest.mark.asyncio
+async def test_max_pages_limit(crawl_tracker, sample_url):
+    """Test that crawler stops when max pages is reached"""
+    # Set max pages to 1
+    crawl_tracker.max_pages = 1
+
+    # Mock pipeline for close_url
+    crawl_tracker.rdb.set("completed_pages", 2)
+
+    # Close URL to increment completed pages
+    await crawl_tracker.close_url(sample_url)
+
+    # Try to get next page
+    next_url = await crawl_tracker.get_page_to_visit()
+    assert next_url == "exit"  # Should return exit signal
+    assert crawl_tracker.limit_reached is True
 
 
-class TestURLCache:
-    def test_initialization(self, url_cache):
-        assert isinstance(url_cache.visited_urls, set)
-        assert isinstance(url_cache.to_visit, set)
-        assert isinstance(url_cache.queues, list)
+@pytest.mark.asyncio
+async def test_url_cache_get_cached_response(
+    crawl_tracker, sample_url, sample_html_content
+):
+    """Test retrieving URL data from cache"""
+    # Mock hget to return content and status
+    url_data = {
+        "attrs": {"crawl_status": CrawlStatus.DOWNLOADED.value, "req_status": 200},
+        "content": "<html>Test</html>",
+    }
 
-    @pytest.fixture(autouse=True)
-    def teardown(self, redis_conn):
-        yield
-        redis_conn.flushall()
+    await crawl_tracker.update_url(sample_url, url_data)
 
-    def test_update_content_new_url(self, url_cache, sample_html_content):
-        url = "https://example.com"
-        content = sample_html_content
-        status = "200"
-
-        # Should work with string content
-        url_cache.update_content(url, content, status)
-        assert url_cache.rdb.hget(url, "content").decode() == content
-        assert url_cache.rdb.hget(url, "req_status").decode() == status
-
-    def test_update_content_non_string_content(self, url_cache):
-        url = "https://example.com"
-        content = {"html": "test content"}
-        status = "200"
-
-        with pytest.raises(ValueError):
-            url_cache.update_content(url, content, status)
-
-    def test_update_content_existing_url(self, url_cache, sample_html_content):
-        # Add a url to the cache
-        url_cache.rdb.hset("https://example.com", "", "404")
-
-        url = "https://example.com"
-        content = sample_html_content
-        status = "200"
-
-        url_cache.update_content(url, content, status)
-        assert url_cache.rdb.hget(url, "content").decode() == content
-        assert url_cache.rdb.hget(url, "req_status").decode() == status
-
-    def test_get_cached_response(self, url_cache, sample_html_content):
-        url = "https://example.com"
-        content = sample_html_content
-        status = 200
-
-        url_cache.update_content(url, content, status)
-
-        # Verify content was stored
-        direct_stored_data = url_cache.rdb.hgetall(url)
-        direct_stored_data = {
-            k.decode(): v.decode() for k, v in direct_stored_data.items()
-        }
-        returned_stored_data = url_cache.get_cached_response(url)
-        assert direct_stored_data["content"] == returned_stored_data[0]
-        assert direct_stored_data["req_status"] == returned_stored_data[1]
+    content = await crawl_tracker.get_cached_response(sample_url)
+    assert content == sample_html_content

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -10,7 +10,6 @@ from simple_crawler.downloader import SiteDownloader
 @pytest.fixture
 def mock_manager():
     manager = Mock()
-    manager.cache = Mock()
     manager.crawl_tracker = Mock()
     manager.db_manager = Mock()
     return manager
@@ -29,9 +28,12 @@ def test_on_success(downloader):
 
     downloader.on_success(url, content, status_code)
 
-    downloader.cache.update_content.assert_called_once_with(url, content, status_code)
-    downloader.crawl_tracker.update_status.assert_called_once_with(
-        url, "downloaded", 200
+    downloader.crawl_tracker.update_url.assert_called_once_with(
+        url,
+        {
+            "attrs": {"crawl_status": "downloaded", "status_code": 200},
+            "content": content,
+        },
     )
 
 
@@ -39,16 +41,14 @@ def test_on_failure(downloader):
     """Test failed download handling"""
     url = "https://example.com"
     crawl_status = "error"
-    content = "<html>error</html>"
     status_code = 404
 
     downloader.crawl_tracker.update_status.return_value = {"some": "data"}
 
-    downloader.on_failure(url, crawl_status, content, status_code)
+    downloader.on_failure(url, crawl_status, status_code)
 
-    downloader.cache.update_content.assert_called_once_with(url, content, status_code)
-    downloader.crawl_tracker.update_status.assert_called_once_with(
-        url, crawl_status, 404
+    downloader.crawl_tracker.update_url.assert_called_once_with(
+        url, {"attrs": {"crawl_status": "error", "status_code": 404}}, close=True
     )
 
 
@@ -56,7 +56,6 @@ def test_on_failure(downloader):
 def test_get_page_elements_disallowed(mock_requests, downloader):
     """Test getting page elements when URL is disallowed"""
     url = "https://example.com/private"
-    downloader.cache.get_cached_response.return_value = (None, None)
 
     with patch.object(downloader, "can_fetch", return_value=False):
         content, status = downloader.get_page_elements(url)
@@ -65,9 +64,10 @@ def test_get_page_elements_disallowed(mock_requests, downloader):
         assert status == 403
         mock_requests.get.assert_not_called()
         # I had trouble mocking on_failure, so I just confirmed the contained methods were called
-        downloader.cache.update_content.assert_called_once_with(url, "", status)
-        downloader.crawl_tracker.update_status.assert_called_once_with(
-            url, "disallowed", 403
+        downloader.crawl_tracker.update_url.assert_called_once_with(
+            url,
+            {"attrs": {"crawl_status": "disallowed", "status_code": 403}},
+            close=True,
         )
 
 
@@ -83,7 +83,6 @@ def test_get_page_elements_success(mock_requests, downloader):
     mock_response.status_code = status_code
     mock_requests.get.return_value = mock_response
 
-    downloader.cache.get_cached_response.return_value = (None, None)
     with patch.object(downloader, "can_fetch", return_value=True):
         content, status = downloader.get_page_elements(url)
 
@@ -91,9 +90,10 @@ def test_get_page_elements_success(mock_requests, downloader):
         assert status == status_code
         # I had trouble mocking on_success, so I just confirmed the contained methods were called
         mock_requests.get.assert_called_once_with(url, timeout=1)
-        downloader.cache.update_content.assert_called_once_with(
-            url, response_content, status_code
-        )
-        downloader.crawl_tracker.update_status.assert_called_once_with(
-            url, "downloaded", 200
+        downloader.crawl_tracker.update_url.assert_called_once_with(
+            url,
+            {
+                "attrs": {"crawl_status": "downloaded", "status_code": 200},
+                "content": response_content,
+            },
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,9 +10,7 @@ from simple_crawler.parser import Parser
 class TestParser(unittest.TestCase):
     def setUp(self):
         self.mock_manager = Mock()
-        self.mock_manager.cache = Mock()
         self.mock_manager.crawl_tracker = Mock()
-        self.mock_manager.db_manager = Mock()
         self.parser = Parser(manager=self.mock_manager)
 
     def test_get_links_from_content(self):
@@ -27,30 +25,38 @@ class TestParser(unittest.TestCase):
             </body>
         </html>
         """
-
+        self.parser.crawl_tracker.get_cached_response.return_value = test_content
         links = self.parser.get_links_from_content(test_url, test_content)
 
         expected_links = {urljoin(test_url, "/page1"), "https://example.com/page2"}
 
         self.assertEqual(links, expected_links)
-        self.mock_manager.crawl_tracker.add_page_to_visit.assert_called()
+        self.mock_manager.crawl_tracker.request_download.assert_called()
 
     def test_on_success(self):
         """Test successful parsing callback"""
         test_url = "https://example.com"
         self.parser.on_success(test_url, ["https://example.com"])
-        self.mock_manager.crawl_tracker.store_linked_urls.assert_called_with(
-            test_url, ["https://example.com"]
-        )
-        self.mock_manager.crawl_tracker.update_status.assert_called_with(
-            test_url, "parsed"
+        self.mock_manager.crawl_tracker.update_url.assert_called_with(
+            test_url,
+            {
+                "attrs": {"crawl_status": "parsed"},
+                "linked_urls": ["https://example.com"],
+            },
         )
 
     def test_on_failure(self):
         """Test failure parsing callback"""
         test_url = "https://example.com"
         self.parser.on_failure(test_url)
-        self.mock_manager.crawl_tracker.update_status.assert_called()
+        print(self.mock_manager.crawl_tracker.update_url.call_args)
+        self.mock_manager.crawl_tracker.update_url.assert_called_with(
+            test_url,
+            {
+                "attrs": {"crawl_status": "error"},
+            },
+            close=True,
+        )
 
     def test_parse_success(self):
         """Test successful parsing of a page"""
@@ -59,9 +65,14 @@ class TestParser(unittest.TestCase):
 
         self.parser.url = test_url
         self.parser.parse(test_url, test_content)
+        self.parser.crawl_tracker.get_cached_response.return_value = test_content
 
-        self.mock_manager.crawl_tracker.update_status.assert_called_with(
-            test_url, "parsed"
+        self.mock_manager.crawl_tracker.update_url.assert_called_with(
+            test_url,
+            {
+                "attrs": {"crawl_status": "parsed"},
+                "linked_urls": ["https://example.com/test"],
+            },
         )
 
     def test_on_failure_called_after_exception(self):
@@ -72,9 +83,10 @@ class TestParser(unittest.TestCase):
         ):
             test_url = "https://example.com"
             test_content = "<html><a href='/test'>Test</a></html>"
-            self.parser.parse(url=test_url, content=test_content)
-            self.mock_manager.crawl_tracker.update_status.assert_called_with(
-                test_url, "error"
+            self.parser.crawl_tracker.get_cached_response.return_value = test_content
+            self.parser.parse(url=test_url)
+            self.mock_manager.crawl_tracker.update_url.assert_called_with(
+                test_url, {"attrs": {"crawl_status": "error"}}, close=True
             )
 
     def test_parse_failure(self):
@@ -85,8 +97,8 @@ class TestParser(unittest.TestCase):
         self.parser.url = test_url
         self.parser.parse(test_url, test_content)
 
-        self.mock_manager.crawl_tracker.update_status.assert_called_with(
-            test_url, "error"
+        self.mock_manager.crawl_tracker.update_url.assert_called_with(
+            test_url, {"attrs": {"crawl_status": "error"}}, close=True
         )
 
     def test_invalid_href(self):


### PR DESCRIPTION
In order to make the functions in CrawlTracker Async, it is advisable to utilize [redis](url) pipelines. This reduces the number of database touches and drastically reduces the possibility of deadlocks.

To do so more effectively, a new url data structure was introduced. It is described in the [README file changed as part of this PR](https://github.com/wischmcj/simple-crawler/pull/7/files#diff-567730f4d1da52b481a3f434200647270be0d2d57ea7860c016b276acc2bb12b).

High level, this PR:
- Combines all logic that makes updates to url data into one function (formerly the update_status function)
     - This function takes a url and data dict representing desired changes (i.e. {'my_attr': value })  as inputs 
- As part of the above, removes the URLCache, with its content functionality subsumed by CrawlTracker 
- Classes that depend on one another (e.g. Downloader provides content to Parser, Parser provides extracted data to DBBullkWriter) now pass urls rather than url_data. The class that receives the url then queries the cache for the needed data.