### PR TITLE
RQ and RQ dashboard integration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ unused_code/recursive_sitemaps.py
 unused_code/events_db.py
 */sqlite.db
 *.rdb
-*simple_crawler/data/*
+simple_crawler/data/*
 unused_code/*
+tests/data/*
+scripts/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp>=3.8.5
+aiohttp>=3.8.5
 aiosqlite>=0.21.0
 asyncio>=3.4.3
 beautifulsoup4>=4.12.0
@@ -7,6 +8,7 @@ beautifulsoup4>=4.12.0
 black>=23.3.0
 cfgv==3.4.0
 distlib==0.3.9
+dlt[duckdb]>=1.11.0
 fakeredis @ git+https://github.com/cunla/fakeredis-py@190f613
 filelock==3.18.0
 identify==2.6.10
@@ -27,16 +29,19 @@ pytest-mock==3.14.0
 
 # Utilities
 python-dotenv>=1.0.0
-
 pyyaml>=6.0.2
 PyYAML==6.0.2
+
 # Core dependencies
 redis>=6.1.0
 requests>=2.31.0
 rich>=14.0.0
-ruff>=0.1.1
 ruff==0.11.8
+flask>=3.0.0
+rq>=2.0.0
+rq-dashboard>=0.6.0
 
 # Database
 sqlalchemy>=2.0.0
+toml>=0.10.2
 virtualenv==20.31.1

--- a/simple_crawler/.gitignore
+++ b/simple_crawler/.gitignore
@@ -1,0 +1,10 @@
+# ignore secrets, virtual environments and typical python compilation artifacts
+secrets.toml
+# ignore basic python artifacts
+.env
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+# ignore duckdb
+*.duckdb
+*.wal

--- a/simple_crawler/app.py
+++ b/simple_crawler/app.py
@@ -1,0 +1,54 @@
+# from flask import Flask, jsonify
+# # from main import crawl
+# app = Flask(__name__)
+
+
+from __future__ import annotations
+
+import redis
+from main import crawl
+from rq import Queue, Worker
+
+# @app.route('/')
+# def hello_world():
+#     return jsonify({"message": "Hello, World!"})
+
+# # @app.route('/crawl/<url>/<max_depth>/<retries>/<check_every>')
+# # def crawl_endpoint(url: str, max_depth: int, retries: int, check_every: int):
+# #     links = crawl(url, max_depth, retries, check_every)
+# #     return links
+
+
+# def test(message: str) -> str:
+#     print(message)
+#     return message
+
+
+# if __name__ == '__main__':
+#     app.run(host='0.0.0.0', port=5000)
+
+
+
+rdb = redis.Redis(host="localhost", port=7777)
+
+
+def hello_world():
+    return print("message")
+
+
+def rq_crawl():
+    rdb.delete("to_visit")
+    rdb.delete("download_requests")
+    rdb.delete("parse_requests")
+
+    queue = Queue(connection=rdb, name="test")
+    queue.enqueue(crawl)
+
+    worker = Worker(queue, connection=rdb)
+    worker.work(burst=True)
+
+    print("hi")
+
+
+if __name__ == "__main__":
+    rq_crawl()


### PR DESCRIPTION
In this request, we add app.py. App.py contains a wrapper function around our crawl function that submits the crawl command as a job to a Redis queue and creates a worker to run said job. A user  can then *optionally* start an instance of rq-dashboard via the command line to monitor the status of the job. Rq-dashboard surfaces a flask app at  http://0.0.0.0:9181/ for this purpose.

For more information on rq queues and rq-dashboard, see (their documentation)[https://python-rq.org/docs/]

Note that the installation instructions have changed - with the addition of rq-dashboard listed as optional.